### PR TITLE
Refactor toString in _RobotBase to not return null to address technical debt

### DIFF
--- a/robocode.api/src/main/java/robocode/_RobotBase.java
+++ b/robocode.api/src/main/java/robocode/_RobotBase.java
@@ -96,7 +96,7 @@ public abstract class _RobotBase implements IBasicRobot, Runnable {
 	 */
 	@Override
 	public String toString() {
-		if (peer == null) return null;
+		if (peer == null) return "";
 		return peer.getName() + " (" + (int) peer.getEnergy() + ") X" + (int) peer.getX() + " Y" + (int) peer.getY()
 				+ " ~" + Utils.angleToApproximateDirection(peer.getBodyHeading());
 	}


### PR DESCRIPTION
Description
This Pull Request resolves technical debt identified in the project by:

Refactoring the toString method in _RobotBase to return an empty string instead of null.
Changes Made
File Updated: src/main/java/robocode/_RobotBase.java

Issue: The toString and clone methods should not return null
Fix: Refactored toString to return empty string.

Related Issues
Fixes #5 