### PR TITLE
SSRF vulnerability merge request

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/root/JarRoot.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/root/JarRoot.java
@@ -192,19 +192,17 @@ public final class JarRoot extends BaseRoot implements IRepositoryRoot {
 
 	private boolean isSafeJarURL(URL url) {
 		try {
-			// Ensure the protocol is "jar"
 			if (!"jar".equalsIgnoreCase(url.getProtocol())) {
 				return false;
 			}
 
 			String path = url.toString();
 
-			// Prevent URLs that resolve to HTTP, FTP, FILE, etc. inside the JAR part
+
 			if (path.contains("http:") || path.contains("https:") || path.contains("ftp:") || path.contains("file:")) {
 				return false;
 			}
 
-			// Optionally, restrict it to a known base directory
 			File file = new File(rootPath.getAbsolutePath()).getCanonicalFile();
 			if (!file.exists() || !file.isFile()) {
 				return false;

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/root/JarRoot.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/root/JarRoot.java
@@ -88,6 +88,11 @@ public final class JarRoot extends BaseRoot implements IRepositoryRoot {
 		JarInputStream jarIS = null;
 
 		try {
+			if (!isSafeJarURL(rootURL)) {
+				Logger.logError("Blocked potentially unsafe JAR URL: " + rootURL);
+				return;
+			}
+
 			URLConnection con = URLJarCollector.openConnection(rootURL);
 
 			is = con.getInputStream();
@@ -126,7 +131,7 @@ public final class JarRoot extends BaseRoot implements IRepositoryRoot {
 							readJarStream(repositoryItems, "jar:jar" + root + JarJar.SEPARATOR + fullName, inner);
 						} finally {
 							if (inner != null) {
-								inner.closeEntry();								
+								inner.closeEntry();
 							}
 						}
 					} else if (name.endsWith(".class")) {
@@ -149,7 +154,7 @@ public final class JarRoot extends BaseRoot implements IRepositoryRoot {
 
 			if (repositoryItem != null) {
 				if (repositoryItem instanceof RobotItem) {
-					RobotItem robotItem = (RobotItem) repositoryItem; 
+					RobotItem robotItem = (RobotItem) repositoryItem;
 
 					robotItem.setClassPathURL(root);
 				}
@@ -183,5 +188,34 @@ public final class JarRoot extends BaseRoot implements IRepositoryRoot {
 	public void extractJAR() {
 		JarExtractor.extractJar(rootURL);
 	}
+
+
+	private boolean isSafeJarURL(URL url) {
+		try {
+			// Ensure the protocol is "jar"
+			if (!"jar".equalsIgnoreCase(url.getProtocol())) {
+				return false;
+			}
+
+			String path = url.toString();
+
+			// Prevent URLs that resolve to HTTP, FTP, FILE, etc. inside the JAR part
+			if (path.contains("http:") || path.contains("https:") || path.contains("ftp:") || path.contains("file:")) {
+				return false;
+			}
+
+			// Optionally, restrict it to a known base directory
+			File file = new File(rootPath.getAbsolutePath()).getCanonicalFile();
+			if (!file.exists() || !file.isFile()) {
+				return false;
+			}
+
+			return true;
+		} catch (IOException e) {
+			Logger.logError("URL validation failed: " + e.getMessage());
+			return false;
+		}
+	}
+
 
 }


### PR DESCRIPTION
This pull request fixes a potential SSRF vulnerability in `JarRoot` by validating URLs derived from JAR files before using them in `openConnection()`. A new `isSafeJarURL()` method ensures only trusted `jar:file://` URLs are allowed. This prevents attackers from exploiting crafted JARs to trigger internal or external network requests.